### PR TITLE
0506 allow ubuntu versions to be a var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,12 @@
 module "server_policy" {
   source = "./modules/server_policy"
 
-  ami_ids      = var.ami_ids
-  key_pair_ids = var.key_pair_ids
-  subnet_ids   = var.subnet_ids
-  vpc_ids      = var.vpc_ids
-  allow_spot   = var.allow_spot
+  ami_ids                         = var.ami_ids
+  key_pair_ids                    = var.key_pair_ids
+  subnet_ids                      = var.subnet_ids
+  vpc_ids                         = var.vpc_ids
+  allow_spot                      = var.allow_spot
+  allow_modify_instance_attribute = var.allow_modify_instance_attribute
 
   agent_role_arn             = aws_iam_role.agent.arn
   agent_instance_profile_arn = aws_iam_instance_profile.agent.arn

--- a/modules/server_policy/main.tf
+++ b/modules/server_policy/main.tf
@@ -32,14 +32,17 @@ data "aws_iam_policy_document" "teamcity_server_cloud_profile" {
     resources = ["*"]
   }
 
-  statement {
-    sid = "InstanceProfileModifyAttributes"
+  dynamic "statement" {
+    for_each = "${var.allow_modify_instance_attribute}" ? [1] : []
+    content {
+      sid = "InstanceProfileModifyAttributes"
 
-    actions = [
-      "ec2:ModifyInstanceAttribute",
-    ]
+      actions = [
+        "ec2:ModifyInstanceAttribute",
+      ]
 
-    resources = ["*"]
+      resources = ["*"]
+    }
   }
 
   statement {

--- a/modules/server_policy/main.tf
+++ b/modules/server_policy/main.tf
@@ -33,6 +33,16 @@ data "aws_iam_policy_document" "teamcity_server_cloud_profile" {
   }
 
   statement {
+    sid = "InstanceProfileModifyAttributes"
+
+    actions = [
+      "ec2:ModifyInstanceAttribute",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
     sid = "InstanceProfileRestrictions"
 
     actions = [

--- a/modules/server_policy/variables.tf
+++ b/modules/server_policy/variables.tf
@@ -10,38 +10,43 @@ variable "ami_ids" {
   description = "List of AMI IDs that can be launched by the TeamCity server"
   type        = list(string)
 
-  default     = ["*"]
+  default = ["*"]
 }
 
 variable "subnet_ids" {
   description = "List of Subnet IDs that instances can be launched into by TeamCity server"
   type        = list(string)
 
-  default     = ["*"]
+  default = ["*"]
 }
 
 variable "key_pair_ids" {
   description = "List of Key Pair IDs that can be used with instances launched by TeamCity server"
   type        = list(string)
 
-  default     = ["*"]
+  default = ["*"]
 }
 
 variable "security_group_ids" {
   description = "List of security group IDs that can be attached to instances launched by TeamCity server"
   type        = list(string)
 
-  default     = ["*"]
+  default = ["*"]
 }
 
 variable "vpc_ids" {
   description = "List of VPC IDs that instances can be launched into by TeamCity server"
   type        = list(string)
 
-  default     = ["*"]
+  default = ["*"]
 }
 
 variable "allow_spot" {
   description = "Allow TeamCity server to use spot instances"
+  default     = false
+}
+
+variable "allow_modify_instance_attribute" {
+  description = "Allow Teamcity server to modify the instances attribute."
   default     = false
 }

--- a/packer.json
+++ b/packer.json
@@ -1,5 +1,5 @@
 {
-    "min_packer_version": "1.1.2",
+    "min_packer_version": "1.4.0",
     "variables": {
         "teamcity_base_url": "",
         "ami_base_name": "teamcity-agent",
@@ -25,7 +25,7 @@
             "subnet_id": "{{user `subnet_id`}}",
             "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
             "ssh_interface": "{{user `ssh_interface`}}",
-            "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidr`}}",
+            "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",
             "source_ami_filter": {
                 "filters": {
                     "virtualization-type": "hvm",

--- a/packer.json
+++ b/packer.json
@@ -5,30 +5,32 @@
         "ami_base_name": "teamcity-agent",
         "aws_region": "ap-southeast-1",
         "subnet_id": "",
-        "temporary_security_group_source_cidr": "0.0.0.0/0",
+        "temporary_security_group_source_cidrs": "0.0.0.0/0",
         "associate_public_ip_address": "true",
         "ssh_interface": "",
         "ebs_volume_size": "50",
         "docker_version": "18.06.0~ce~3-0~ubuntu",
-        "docker_compose_version": "1.22.0"
+        "docker_compose_version": "1.22.0",
+        "ami_filter_name": "*ubuntu-bionic-18.04-amd64-server-*",
+        "ami_description": "An Ubuntu 18.04 LTS AMI for TeamCity agents."
     },
     "builders": [
         {
             "name": "teamcity-agent-ami",
             "ami_name": "{{ user `ami_base_name` }}-{{isotime | clean_ami_name}}",
-            "ami_description": "An Ubuntu 18.04 AMI for TeamCity agents.",
+            "ami_description": "{{ user `ami_description` }}",
             "instance_type": "t3.micro",
             "region": "{{user `aws_region`}}",
             "type": "amazon-ebs",
             "subnet_id": "{{user `subnet_id`}}",
             "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
             "ssh_interface": "{{user `ssh_interface`}}",
-            "temporary_security_group_source_cidr": "{{user `temporary_security_group_source_cidr`}}",
+            "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidr`}}",
             "source_ami_filter": {
                 "filters": {
                     "virtualization-type": "hvm",
                     "architecture": "x86_64",
-                    "name": "*ubuntu-bionic-18.04-amd64-server-*",
+                    "name": "{{ user `ami_filter_name` }}",
                     "block-device-mapping.volume-type": "gp2",
                     "root-device-type": "ebs"
                 },

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "subnet_ids" {
   description = "List of Subnet IDs that instances can be launched into by TeamCity server"
   type        = list(string)
 
-  default     = ["*"]
+  default = ["*"]
 }
 
 variable "server_policy_name" {
@@ -22,14 +22,14 @@ variable "ami_ids" {
   description = "List of AMI IDs that can be launched by the TeamCity server"
   type        = list(string)
 
-  default     = ["*"]
+  default = ["*"]
 }
 
 variable "key_pair_ids" {
   description = "List of Key Pair IDs that can be used with instances launched by TeamCity server"
   type        = list(string)
 
-  default     = ["*"]
+  default = ["*"]
 }
 
 variable "allow_spot" {
@@ -69,4 +69,9 @@ variable "tags" {
   default = {
     Terraform = "true"
   }
+}
+
+variable "allow_modify_instance_attribute" {
+  description = "Allow Teamcity server to modify the instances attribute."
+  default     = false
 }


### PR DESCRIPTION
changes made:

1. renamed temporary_security_group_source_cidr -> temporary_security_group_source_cidrs, due to deprecation of temporary_security_group_source_cidr. see [link](https://github.com/hashicorp/packer/blob/master/CHANGELOG.md)

2. refactored ami_filter_name + ami_description to be used as input variables instead, to allow user control of ubuntu ami types.

3. added ec2:ModifyInstanceAttribute to teamcity server user policy. this is needed for ebs-instance sources in cloud profiles. [see link](https://www.jetbrains.com/help/teamcity/setting-up-teamcity-for-amazon-ec2.html#SettingUpTeamCityforAmazonEC2-RequiredIAMpermissions)